### PR TITLE
Fix jitpack URL to prevent 522 errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
     }
 
     dependencies {
@@ -17,7 +17,7 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Jitpack sometimes times out when trying to resolve packages with `https://jitpack.io` instead of `https://www.jitpack.io`.

We are experiencing this issue with the `flutter_image_cropper` package trying to resolve the ucrop package

```
from server: Origin Connection Time-out
   > Could not resolve com.github.yalantis:ucrop:2.2.4.
     Required by:
         project :app > project :image_cropper
```

Please see
https://github.com/OneSignal/OneSignal-Android-SDK/issues/843 and https://github.com/jitpack/jitpack.io/issues/3983 for similar issues.