### PR TITLE
add sdk version constraint to example app

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,8 @@ description: Demonstrates how to use the flutter_image_cropper plugin.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
 
+environment:
+  sdk: '>=2.10.0 <3.0.0'
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
when I build the example app, below error are occurred.

```
pubspec.yaml has no lower-bound SDK constraint.
You should edit pubspec.yaml to contain an SDK constraint:

environment:
  sdk: '>=2.10.0 <3.0.0'

See https://dart.dev/go/sdk-constraint
```

and, this error can be cured by add SDK constraint. 
(tested)