### PR TITLE
Fix active window logic

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,10 @@ description: Demonstrates how to use the flutter_image_cropper plugin.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
 
+environment:
+  sdk: '>=1.20.1 <3.0.0'
+  flutter: ^1.12.13
+
 dependencies:
   flutter:
     sdk: flutter

--- a/ios/Classes/FLTImageCropperPlugin.m
+++ b/ios/Classes/FLTImageCropperPlugin.m
@@ -10,7 +10,6 @@
 @implementation FLTImageCropperPlugin {
     FlutterResult _result;
     NSDictionary *_arguments;
-    UIViewController *_viewController;
     float _compressQuality;
     NSString *_compressFormat;
 }
@@ -18,17 +17,30 @@
     FlutterMethodChannel* channel = [FlutterMethodChannel
       methodChannelWithName:@"plugins.hunghd.vn/image_cropper"
             binaryMessenger:[registrar messenger]];
-    UIViewController *viewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-    FLTImageCropperPlugin* instance = [[FLTImageCropperPlugin alloc] initWithViewController:viewController];
+    FLTImageCropperPlugin* instance = [[FLTImageCropperPlugin alloc] init];
     [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (instancetype)initWithViewController:(UIViewController *)viewController {
-    self = [super init];
-    if (self) {
-        _viewController = viewController;
+- (UIViewController *)_viewController {
+    NSArray<UIWindow*>* windows = [UIApplication sharedApplication].windows;
+    
+    NSArray<UIWindow*>* activeWindows = [windows filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(UIWindow* object, NSDictionary *bindings) {
+        return object.isHidden == NO;
+    }]];
+    
+    UIWindow* firstActiveWindow = activeWindows.firstObject;
+    if (firstActiveWindow == nil) {
+        [NSException raise:@"NilWindow" format:@"Unable to retrieve active window"];
+        return nil;
     }
-    return self;
+    
+    UIViewController* rootViewController = firstActiveWindow.rootViewController;
+    if (rootViewController == nil) {
+        [NSException raise:@"NilRootViewController" format:@"Unable to retrieve rootViewController"];
+        return nil;
+    }
+    
+    return rootViewController;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -83,7 +95,7 @@
           cropViewController.aspectRatioLockEnabled = YES;
       }
       
-      [_viewController presentViewController:cropViewController animated:YES completion:nil];
+      [self._viewController presentViewController:cropViewController animated:YES completion:nil];
   } else {
       result(FlutterMethodNotImplemented);
   }


### PR DESCRIPTION
This PR makes some changes to the way that the active window is retrieved.

The current logic made some assumptions around the hierarchy expected for the UIWindow that didn't always hold true.
This instead delays retrieving the active window until the image cropper is about to be launched (because the active window may have changed between plugin initialization and the time where we go and display the image cropper).

Additionally it iterates over the list of windows to find the first window that isn't hidden to ensure that we're not trying to present the image cropper on a hidden window.