### PR TITLE
change ios target from 8.0 to 9.0

### DIFF
--- a/ios/image_cropper.podspec
+++ b/ios/image_cropper.podspec
@@ -17,6 +17,6 @@ A Flutter plugin supports cropping images
   s.dependency 'Flutter'
   s.dependency 'TOCropViewController', '~> 2.6.1'
   
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
 end
 


### PR DESCRIPTION
this change is used to synchronize ios target development image_picker and image_cropper, so we can use the latest  version of image_cropper and image_picker at the same time