### PR TITLE
consolidating result options in an anonymous class

### DIFF
--- a/image_cropper/pubspec.yaml
+++ b/image_cropper/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter:
     sdk: flutter
   image_cropper_platform_interface: ^2.0.0
-  image_cropper_for_web: ^0.0.4
+  image_cropper_for_web:
 
 dev_dependencies:
   flutter_test:

--- a/image_cropper_for_web/lib/src/croppie/croppie_dart.dart
+++ b/image_cropper_for_web/lib/src/croppie/croppie_dart.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';
+
 import 'package:js/js.dart';
 
 import 'croppie_dart_base.dart';
@@ -50,8 +51,7 @@ abstract class CroppieBase {
   ///     Default = 1
   /// circle = force the result to be cropped into a circle
   ///     Valid Values: bool
-  Promise result(
-      String type, String size, String format, num quality, bool circle);
+  Promise result(ResultOptions options);
 
   /// Rotate the image by a specified degree amount. Only works with enableOrientation option enabled (see 'Options').
   /// degrees Valid Values: 90, 180, 270, -90, -180, -270
@@ -139,9 +139,19 @@ class _Croppie implements Croppie {
   }
 
   @override
-  Promise result(
+  Promise result(ResultOptions options) {
+    return impl.result(options);
+  }
+
+  @override
+  Promise _result(
       String? type, String? size, String? format, num? quality, bool? circle) {
-    return impl.result(type, size, format, quality, circle);
+    return impl.result(ResultOptions(
+        type: type,
+        size: size,
+        format: format,
+        quality: quality,
+        circle: circle));
   }
 
   @override
@@ -152,7 +162,7 @@ class _Croppie implements Croppie {
     num? quality,
     bool? circle,
   }) {
-    Promise promise = result(type, size, format, quality, circle);
+    Promise promise = _result(type, size, format, quality, circle);
     return _completerForPromise<T>(promise).future;
   }
 
@@ -163,7 +173,7 @@ class _Croppie implements Croppie {
     num? quality,
     bool? circle,
   }) {
-    Promise promise = result("base64", size, format, quality, circle);
+    Promise promise = _result("base64", size, format, quality, circle);
     return _completerForPromise<String?>(promise).future;
   }
 
@@ -174,7 +184,7 @@ class _Croppie implements Croppie {
     num? quality,
     bool? circle,
   }) {
-    Promise promise = result("html", size, format, quality, circle);
+    Promise promise = _result("html", size, format, quality, circle);
     return _completerForPromise<T>(promise).future;
   }
 
@@ -185,7 +195,7 @@ class _Croppie implements Croppie {
     num? quality,
     bool? circle,
   }) {
-    Promise promise = result("blob", size, format, quality, circle);
+    Promise promise = _result("blob", size, format, quality, circle);
     return _completerForPromise<Blob?>(promise).future;
   }
 
@@ -225,7 +235,7 @@ class _Croppie implements Croppie {
     num? quality,
     bool? circle,
   }) async {
-    Promise promise = result("rawcanvas", size, format, quality, circle);
+    Promise promise = _result("rawcanvas", size, format, quality, circle);
     return _completerForPromise<CanvasElement?>(promise).future;
   }
 

--- a/image_cropper_for_web/lib/src/croppie/croppie_dart_base.dart
+++ b/image_cropper_for_web/lib/src/croppie/croppie_dart_base.dart
@@ -2,6 +2,7 @@
 library chroppie.native;
 
 import 'dart:html';
+
 import 'package:js/js.dart';
 
 import 'croppie_dart.dart';
@@ -24,6 +25,20 @@ class BindConfiguration {
   external List<String> get points;
   external int get orientation;
   external double get zoom;
+}
+
+/// Options for result()
+@JS()
+@anonymous
+class ResultOptions {
+  external factory ResultOptions(
+      {String? type, String? size, String? format, num? quality, bool? circle});
+
+  external String? get type;
+  external String? get size;
+  external String? get format;
+  external num? get quality;
+  external bool? get circle;
 }
 
 /// Result of the get() function.
@@ -127,8 +142,7 @@ class CroppieJS implements CroppieBase {
 
   external Promise bind(BindConfiguration conf);
 
-  external Promise result(
-      String? type, String? size, String? format, num? quality, bool? circle);
+  external Promise result(ResultOptions options);
 
   external void rotate(int degrees);
 

--- a/image_cropper_for_web/pubspec.yaml
+++ b/image_cropper_for_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: image_cropper_for_web
 description: A Flutter plugin for Web supports cropping images
 repository: https://github.com/hnvn/flutter_image_cropper
-version: 0.0.4
+version: 0.0.5
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
Wraps the params in the results function into a class so that `Croppie` would properly read the `format` and other params. Otherwise only the `type` param is taken into account by `Croppie` library.