### PR TITLE
Feature/web optional barrier color

### DIFF
--- a/image_cropper_for_web/lib/image_cropper_for_web.dart
+++ b/image_cropper_for_web/lib/image_cropper_for_web.dart
@@ -199,6 +199,7 @@ class ImageCropperPlugin extends ImageCropperPlatform {
       }
       final result = await showDialog<String?>(
         context: context,
+        barrierColor: webSettings.barrierColor,
         builder: (_) => cropperDialog,
       );
 

--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -431,6 +431,9 @@ class WebUiSettings extends PlatformUiSettings {
   /// Builder to customize the cropper [PageRoute]
   final CropperRouteBuilder? customRouteBuilder;
 
+  /// Barrier color for displayed [Dialog]
+  final Color? barrierColor;
+
   WebUiSettings({
     required this.context,
     this.presentStyle = CropperPresentStyle.dialog,
@@ -446,6 +449,7 @@ class WebUiSettings extends PlatformUiSettings {
     this.enforceBoundary,
     this.mouseWheelZoom,
     this.showZoomer,
+    this.barrierColor,
   });
 
   @override


### PR DESCRIPTION
Adds an optional `barrierColor` to `WebSettings` which is used as `barrierColor` by `showDialog` when `CropperPresentStyle.dialog`.