### PR TITLE
Added size parameter which should result in original scale crops.

### DIFF
--- a/image_cropper_for_web/lib/image_cropper_for_web.dart
+++ b/image_cropper_for_web/lib/image_cropper_for_web.dart
@@ -145,6 +145,7 @@ class ImageCropperPlugin extends ImageCropperPlatform {
     Future<String?> doCrop() async {
       final blob = await croppie.resultBlob(
         format: format,
+        size: 'original',
         quality: quality,
       );
       if (blob != null) {


### PR DESCRIPTION
Added the `size` parameter set to `original` as described in http://foliotek.github.io/Croppie/#documentation to get full size crops rather than crops sized at viewport scale.

I've moved on from this plugin as the web implementation doesn't seem to be at the same level as ios & android.

https://github.com/hnvn/flutter_image_cropper/issues/399#issuecomment-1433963244