### PR TITLE
Fix window access issue with SceneDelegate on iOS 13+

### DIFF
--- a/image_cropper/ios/Classes/FLTImageCropperPlugin.m
+++ b/image_cropper/ios/Classes/FLTImageCropperPlugin.m
@@ -83,7 +83,21 @@
       
       [self setupUiCustomizedOptions:call.arguments forViewController:cropViewController];
 
-      [[UIApplication sharedApplication].delegate.window.rootViewController presentViewController:cropViewController animated:YES completion:nil];
+      UIWindow *window = [UIApplication sharedApplication].delegate.window;
+      if (!window && @available(iOS 13.0, *)) {
+          for (UIWindowScene* scene in [UIApplication sharedApplication].connectedScenes) {
+              if (scene.activationState == UISceneActivationStateForegroundActive) {
+                  for (UIWindow *w in scene.windows) {
+                      if (w.isKeyWindow) {
+                          window = w;
+                          break;
+                      }
+                  }
+              }
+          }
+      }
+
+      [window.rootViewController presentViewController:cropViewController animated:YES completion:nil];
   } else {
       result(FlutterMethodNotImplemented);
   }


### PR DESCRIPTION
Fix the issue that when using SceneDelegate to launch the app on iOS 13 or above, the window cannot be obtained from the AppDelegate, by adding a check to use `[UIApplication sharedApplication].connectedScenes` to get the window only when `[UIApplication sharedApplication].delegate.window` not found.