### PR TITLE
feat: Add Spanish translations for web interface

### DIFF
--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -507,4 +507,11 @@ class WebTranslations {
         rotateRightTooltip = 'Rotate 90 degree clockwise',
         cancelButton = 'Cancel',
         cropButton = 'Crop';
+
+  const WebTranslations.es()
+      : title = 'Recortar y rotar',
+        rotateLeftTooltip = 'Rotar 90 grados a la izquierda',
+        rotateRightTooltip = 'Rotar 90 grados a la derecha',
+        cancelButton = 'Cancelar',
+        cropButton = 'Recortar';
 }


### PR DESCRIPTION
This commit adds a new constructor to the `WebTranslations` class that includes Spanish translations for the web interface. The new constructor includes translations for the title, rotate left and right tooltips, cancel button, and crop button.