### PR TITLE
Aspect Ratio Patch

### DIFF
--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -12,6 +12,7 @@ enum CropAspectRatioPreset {
   ratio3x2,
   ratio5x3,
   ratio4x3,
+  ratio5x1,
   ratio5x4,
   ratio7x5,
   ratio16x9
@@ -63,6 +64,8 @@ String aspectRatioPresetName(CropAspectRatioPreset? preset) {
       return '3x2';
     case CropAspectRatioPreset.ratio4x3:
       return '4x3';
+    case CropAspectRatioPreset.ratio5x1:
+      return '5x1';
     case CropAspectRatioPreset.ratio5x3:
       return '5x3';
     case CropAspectRatioPreset.ratio5x4:


### PR DESCRIPTION
I have been struggling to create a custom AspectRationPreset, in our projects, we use a lot of 5x1 ratio. So I have added this ratio to `image_cropper_platform-interface>lib>src>model>settings.dart`