### PR TITLE
Migrate from js to dart:interop_js | Migrate from dart:html to web

### DIFF
--- a/image_cropper/pubspec.yaml
+++ b/image_cropper/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   flutter:
     sdk: flutter
   image_cropper_platform_interface: ^5.0.0
-  image_cropper_for_web: ^4.0.0
+  image_cropper_for_web: ^4.0.1
 
 dev_dependencies:
   flutter_test:

--- a/image_cropper_for_web/lib/image_cropper_for_web.dart
+++ b/image_cropper_for_web/lib/image_cropper_for_web.dart
@@ -1,6 +1,6 @@
 library image_cropper_for_web;
 
-import 'dart:html' as html;
+import 'package:web/web.dart' as web;
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
@@ -101,7 +101,7 @@ class ImageCropperPlugin extends ImageCropperPlatform {
     final context = webSettings.context;
     final shapeType = cropStyle == CropStyle.circle ? 'circle' : 'square';
 
-    final element = html.DivElement();
+    final element = web.HTMLDivElement();
     final option = Options(
       boundary: webSettings.boundary == null
           ? Boundary(width: 500, height: 500)
@@ -148,7 +148,7 @@ class ImageCropperPlugin extends ImageCropperPlatform {
         quality: quality,
       );
       if (blob != null) {
-        final blobUrl = html.Url.createObjectUrlFromBlob(blob);
+        final blobUrl = web.URL.createObjectURL(blob);
         return blobUrl;
       }
       return null;

--- a/image_cropper_for_web/lib/src/croppie/croppie_dart.dart
+++ b/image_cropper_for_web/lib/src/croppie/croppie_dart.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:html';
+import 'package:web/web.dart';
 import 'dart:typed_data';
-import 'package:js/js.dart';
+import "dart:js_util";
 
 import 'croppie_dart_base.dart';
 

--- a/image_cropper_for_web/lib/src/croppie/croppie_dart_base.dart
+++ b/image_cropper_for_web/lib/src/croppie/croppie_dart_base.dart
@@ -1,9 +1,9 @@
 @JS()
 library chroppie.native;
 
-import 'dart:html';
+import 'package:web/web.dart';
 
-import 'package:js/js.dart';
+import "dart:js_interop";
 
 import 'croppie_dart.dart';
 

--- a/image_cropper_for_web/pubspec.yaml
+++ b/image_cropper_for_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: image_cropper_for_web
 description: A Flutter plugin for Web supports cropping images
 repository: https://github.com/hnvn/flutter_image_cropper
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: '>=2.18.0 <4.0.0'
@@ -12,10 +12,10 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  
+
   image_cropper_platform_interface: ^5.0.0
 
-  js: ^0.7.1
+  web: ^0.5.1
 
 
 dev_dependencies:


### PR DESCRIPTION
With flutter 3.22 it is possible to build with `--wasm`. Also, many packages conflict with older versions of js. Therefore I created a fork that migrates js to interop_js and dart:html to web. It seems to work

Links:

- https://dart.dev/interop/js-interop
- https://dart.dev/interop/js-interop/package-web