### PR TITLE
Lock rotation option for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ From v1.2.0, you need to migrate your android project to v2 embedding ([detail](
 <summary>Click to view detail</summary>
 <br/>
 
-**Image Cropper** provides a helper class called `IOUiSettings` that wraps all properties can be used to customize UI in **TOCropViewController** library. 
+**Image Cropper** provides a helper class called `IOSUiSettings` that wraps all properties can be used to customize UI in **TOCropViewController** library. 
 
 | Property                              | Description                                                                                                                                                                                                                                                                                                                                 | Type                            |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -66,7 +66,7 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         // uCrop.withMaxResultSize(1000, 1000);
         options.setCompressionFormat("png".equals(compressFormat) ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(compressQuality != null ? compressQuality : 90);
-        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.ALL));
+        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.ALL);
         options.setMaxBitmapSize(10000);
 
         // UI customization settings

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -65,6 +65,7 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         // uCrop.withMaxResultSize(1000, 1000);
         options.setCompressionFormat("png".equals(compressFormat) ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(compressQuality != null ? compressQuality : 90);
+        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.SCALE);
         options.setMaxBitmapSize(10000);
 
         // UI customization settings

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -66,7 +66,7 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         // uCrop.withMaxResultSize(1000, 1000);
         options.setCompressionFormat("png".equals(compressFormat) ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(compressQuality != null ? compressQuality : 90);
-        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.ALL);
+        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.SCALE);
         options.setMaxBitmapSize(10000);
 
         // UI customization settings

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -11,6 +11,7 @@ import androidx.preference.PreferenceManager;
 import com.yalantis.ucrop.UCrop;
 import com.yalantis.ucrop.model.AspectRatio;
 import com.yalantis.ucrop.view.CropImageView;
+import com.yalantis.ucrop.UCropActivity;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -65,7 +66,7 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         // uCrop.withMaxResultSize(1000, 1000);
         options.setCompressionFormat("png".equals(compressFormat) ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(compressQuality != null ? compressQuality : 90);
-        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.SCALE);
+        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.ROTATE, UCropActivity.ALL));
         options.setMaxBitmapSize(10000);
 
         // UI customization settings

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -49,6 +49,8 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         ArrayList<Map<?, ?>> aspectRatioPresets = call.argument("android.aspect_ratio_presets");
         String cropStyle = call.argument("android.crop_style");
         String initAspectRatio = call.argument("android.init_aspect_ratio");
+        boolean lockGestureRotation = call.argument("android.lock_gesture_rotation");
+
 
         pendingResult = result;
 
@@ -66,7 +68,9 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         // uCrop.withMaxResultSize(1000, 1000);
         options.setCompressionFormat("png".equals(compressFormat) ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG);
         options.setCompressionQuality(compressQuality != null ? compressQuality : 90);
-        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.SCALE);
+        if(lockGestureRotation){
+            options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.SCALE);
+        }
         options.setMaxBitmapSize(10000);
 
         // UI customization settings

--- a/image_cropper/pubspec.yaml
+++ b/image_cropper/pubspec.yaml
@@ -21,7 +21,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  image_cropper_platform_interface: ^7.0.0
+  image_cropper_platform_interface: ^7.0.1
   image_cropper_for_web: ^6.0.2
 
 dev_dependencies:

--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -198,6 +198,9 @@ class AndroidUiSettings extends PlatformUiSettings {
   /// when starting the cropper
   final CropAspectRatioPresetData? initAspectRatio;
 
+  /// Locks rotation of the image when gestures are used (default is false)
+  final bool lockGestureRotation;
+
   AndroidUiSettings({
     this.toolbarTitle,
     this.toolbarColor,
@@ -217,6 +220,7 @@ class AndroidUiSettings extends PlatformUiSettings {
     this.hideBottomControls,
     this.initAspectRatio,
     this.cropStyle = CropStyle.rectangle,
+    this.lockGestureRotation = false,
     this.aspectRatioPresets = const [
       CropAspectRatioPreset.original,
       CropAspectRatioPreset.square,
@@ -247,6 +251,7 @@ class AndroidUiSettings extends PlatformUiSettings {
         'android.hide_bottom_controls': this.hideBottomControls,
         'android.init_aspect_ratio': this.initAspectRatio?.name,
         'android.crop_style': this.cropStyle.name,
+        'android.lock_gesture_rotation': this.lockGestureRotation,
         'android.aspect_ratio_presets': aspectRatioPresets
             .map<Map<String, dynamic>>((item) => {
                   'name': item.name,

--- a/image_cropper_platform_interface/pubspec.yaml
+++ b/image_cropper_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: image_cropper_platform_interface
 description: A common platform interface for the image_cropper plugin.
 repository: https://github.com/hnvn/flutter_image_cropper
-version: 7.0.0
+version: 7.0.1
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Issue:
- From user experience rotating image can be not comfortable while cropping an image
## Solution:
- added `lockGestureRotation` boolean to be able to modify from Flutter