### PR TITLE
Update uCrop version to 2.2.11

### DIFF
--- a/image_cropper/android/build.gradle
+++ b/image_cropper/android/build.gradle
@@ -38,7 +38,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.github.yalantis:ucrop:2.2.10'
+        implementation 'com.github.yalantis:ucrop:2.2.11'
         implementation 'androidx.preference:preference:1.2.1'
     }
 }

--- a/image_cropper/android/build.gradle
+++ b/image_cropper/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://www.jitpack.io" }
+		maven { url 'https://jitpack.io' }
     }
 
     dependencies {
@@ -17,7 +17,7 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://www.jitpack.io" }
+		maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
- Fixes bug with the Android library androidx.exifinterface:exifinterface on the old uCrop version (2.2.10) in this Flutter package