### PR TITLE
Change status bar color setting to toolbar color

### DIFF
--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -196,9 +196,9 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         }
         else{
         if (statusBarColor != null) {
-            options.setStatusBarColor(statusBarColor);
+            options.setToolbarColor(statusBarColor);
         } else if (toolbarColor != null) {
-            options.setStatusBarColor(darkenColor(toolbarColor));
+            options.setToolbarColor(darkenColor(toolbarColor));
         }
         }
         if (toolbarWidgetColor != null) {


### PR DESCRIPTION
Looks like `setStatusBarColor` no longer exists in the latest uCrop version, and has been updated to `setToolbarColor`.

The current version on `main` does not compile on Android, due to the missing method.