### PR TITLE
IOS 26 Bottom SafeArea Fixes

### DIFF
--- a/image_cropper/ios/image_cropper.podspec
+++ b/image_cropper/ios/image_cropper.podspec
@@ -15,7 +15,7 @@ A Flutter plugin supports cropping images
   s.source_files = 'image_cropper/Sources/**/*'
   s.public_header_files = 'image_cropper/Sources/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TOCropViewController', '~> 2.7.4'
+  s.dependency 'TOCropViewController', '~> 2.8.0'
   
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
 end


### PR DESCRIPTION
fix(ios): bump TOCropViewController to 2.8.0 and set iOS deployment target to 12.0 to resolve bottom buttons safe area issue on iOS 26