### PR TITLE
Fix Android release build compile error

### DIFF
--- a/image_cropper/android/build.gradle
+++ b/image_cropper/android/build.gradle
@@ -33,6 +33,11 @@ android {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    buildTypes {
+        release {
+            consumerProguardFiles 'consumer-proguard-rules.pro'
+        }
+    }
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/image_cropper/android/consumer-proguard-rules.pro
+++ b/image_cropper/android/consumer-proguard-rules.pro
@@ -1,0 +1,7 @@
+# Keep OkHttp classes for UCrop
+-keep class okhttp3.** { *; }
+-dontwarn okhttp3.**
+
+# Keep UCrop classes
+-keep class com.yalantis.ucrop.** { *; }
+-dontwarn com.yalantis.ucrop.**


### PR DESCRIPTION
This PR fixes #593 

Resolve Android release build compile error by adding consumer ProGuard rules for OkHttp and UCrop

Added `consumer-proguard-rules.pro` and updated `build.gradle` to include it, so apps
using minifyEnabled true no longer need to add manual rules.
