### PR TITLE
fix(ios): remove forced aspectRatioLockDimensionSwapEnabled=YES when aspect ratio is set

### DIFF
--- a/image_cropper/ios/image_cropper/Sources/image_cropper/FLTImageCropperPlugin.m
+++ b/image_cropper/ios/image_cropper/Sources/image_cropper/FLTImageCropperPlugin.m
@@ -81,7 +81,6 @@
       cropViewController.aspectRatioPreset = CGSizeMake([ratioX floatValue], [ratioY floatValue]);
       cropViewController.resetAspectRatioEnabled = NO;
       cropViewController.aspectRatioPickerButtonHidden = YES;
-      cropViewController.aspectRatioLockDimensionSwapEnabled = YES;
       cropViewController.aspectRatioLockEnabled = YES;
     }
 


### PR DESCRIPTION
## Problem

When `CropAspectRatio` is specified via the `aspectRatio` parameter, the plugin unconditionally forces `aspectRatioLockDimensionSwapEnabled = YES` on the `TOCropViewController`:

```objc
// FLTImageCropperPlugin.m
[self setupUiCustomizedOptions:call.arguments forViewController:cropViewController];  // ← applies user value (NO by default)

if (ratioX != (id)[NSNull null] && ratioY != (id)[NSNull null]) {
    cropViewController.aspectRatioPreset = CGSizeMake([ratioX floatValue], [ratioY floatValue]);
    cropViewController.resetAspectRatioEnabled = NO;
    cropViewController.aspectRatioPickerButtonHidden = YES;
    cropViewController.aspectRatioLockDimensionSwapEnabled = YES;  // ← overrides user value unconditionally
    cropViewController.aspectRatioLockEnabled = YES;
}
```

`setupUiCustomizedOptions` is called first and correctly applies the caller-provided `IOSUiSettings.aspectRatioLockDimensionSwapEnabled` (or leaves it at the `TOCropViewController` default of `NO`). The block that follows then unconditionally overrides it with `YES`, ignoring the caller's intent.

## Impact

When `aspectRatioLockEnabled` is `true` and the user taps the rotation button, `TOCropViewController` checks `aspectRatioLockDimensionSwapEnabled` to decide whether to swap the crop frame's width and height. With the forced `YES`, the dimensions always swap — even when the caller explicitly set `aspectRatioLockDimensionSwapEnabled: false` in `IOSUiSettings`.

This is particularly problematic for use cases like photo printing, where the crop orientation must remain fixed regardless of image rotation.

## Fix

Remove the forced `cropViewController.aspectRatioLockDimensionSwapEnabled = YES;` line so that:

- If `IOSUiSettings.aspectRatioLockDimensionSwapEnabled` is explicitly set, that value (applied by `setupUiCustomizedOptions`) is respected.
- If not set, the `TOCropViewController` default (`NO` — no swap on rotation) applies.

## Steps to reproduce

```dart
await ImageCropper().cropImage(
  sourcePath: sourcePath,
  aspectRatio: CropAspectRatio(ratioX: 1.5, ratioY: 1),
  uiSettings: [
    IOSUiSettings(
      aspectRatioLockEnabled: true,
      aspectRatioLockDimensionSwapEnabled: false,
    ),
  ],
);
```

Tap the rotation button → the crop frame's portrait/landscape orientation swaps, despite `aspectRatioLockDimensionSwapEnabled: false`.

## After fix

The crop frame maintains its orientation on rotation. `aspectRatioLockDimensionSwapEnabled` behaves as documented.