### PR TITLE
feat(android): expose freeStyleCropEnabled on AndroidUiSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ JavaScript image cropper.
 | `cropGridStrokeWidth`       | desired width of crop grid lines in pixels                                                                 | int                             |
 | `showCropGrid`              | set to true if you want to see a crop grid/guidelines on top of an image                                   | bool                            |
 | `lockAspectRatio`           | set to true if you want to lock the aspect ratio of crop bounds with a fixed value (locked by default)     | bool                            |
+| `freeStyleCropEnabled`      | set to true to let the user resize the crop frame by dragging its corners. Independent of `lockAspectRatio` — set both to `true` to match iOS' "locked ratio + draggable corners" behaviour. When `null`, freestyle is enabled iff `lockAspectRatio` is `false` (legacy default). | bool                            |
 | `hideBottomControls`        | set to true to hide the bottom controls (shown by default)                                                 | bool                            |
 | `initAspectRatio`           | desired aspect ratio is applied (from the list of given aspect ratio presets) when starting the cropper    | CropAspectRatioPreset           |
 | `cropStyle`                 | controls the style of crop bounds, it can be rectangle or circle style (default is `CropStyle.rectangle`). | CropStyle                       |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ JavaScript image cropper.
 | `cropGridStrokeWidth`       | desired width of crop grid lines in pixels                                                                 | int                             |
 | `showCropGrid`              | set to true if you want to see a crop grid/guidelines on top of an image                                   | bool                            |
 | `lockAspectRatio`           | set to true if you want to lock the aspect ratio of crop bounds with a fixed value (locked by default)     | bool                            |
+| `freeStyleCropEnabled`      | set to true to let the user resize the crop frame by dragging its corners. Independent of `lockAspectRatio`. When `null`, freestyle is enabled iff `lockAspectRatio` is `false`. | bool                            |
+| `freeStyleCropShrinkOnly`   | shrink-only crop frame (iOS parity); requires `freeStyleCropEnabled: true` | bool                            |
 | `freeStyleCropEnabled`      | set to true to let the user resize the crop frame by dragging its corners. Independent of `lockAspectRatio` — set both to `true` to match iOS' "locked ratio + draggable corners" behaviour. When `null`, freestyle is enabled iff `lockAspectRatio` is `false` (legacy default). | bool                            |
 | `hideBottomControls`        | set to true to hide the bottom controls (shown by default)                                                 | bool                            |
 | `initAspectRatio`           | desired aspect ratio is applied (from the list of given aspect ratio presets) when starting the cropper    | CropAspectRatioPreset           |

--- a/image_cropper/CHANGELOG.md
+++ b/image_cropper/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Android: add `freeStyleCropEnabled` to `AndroidUiSettings` so callers can opt into uCrop's draggable corner handles independently of `lockAspectRatio`. Lets Android match iOS' "locked aspect ratio + resizable corners" UX. Defaults to `null`, preserving the previous `!lockAspectRatio` behaviour.
+- Android: add `freeStyleCropShrinkOnly` and `CmUCropActivity` so the crop frame can shrink but not expand past its initial size (iOS parity).
 
 ## 12.2.0
 

--- a/image_cropper/CHANGELOG.md
+++ b/image_cropper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Android: add `freeStyleCropEnabled` to `AndroidUiSettings` so callers can opt into uCrop's draggable corner handles independently of `lockAspectRatio`. Lets Android match iOS' "locked aspect ratio + resizable corners" UX. Defaults to `null`, preserving the previous `!lockAspectRatio` behaviour.
+
 ## 12.2.0
 
 - fix issue on iOS: `Lexical or Preprocessor Issue (Xcode): 'TOCropViewController/TOCropViewConstants.h' file not found`

--- a/image_cropper/README.md
+++ b/image_cropper/README.md
@@ -133,6 +133,7 @@ JavaScript image cropper.
 | `showCropGrid`              | set to true if you want to see a crop grid/guidelines on top of an image                                   | bool                            |
 | `lockAspectRatio`           | set to true if you want to lock the aspect ratio of crop bounds with a fixed value (locked by default)     | bool                            |
 | `freeStyleCropEnabled`      | set to true to let the user resize the crop frame by dragging its corners. Independent of `lockAspectRatio` — set both to `true` to match iOS' "locked ratio + draggable corners" behaviour. When `null`, freestyle is enabled iff `lockAspectRatio` is `false` (legacy default). | bool                            |
+| `freeStyleCropShrinkOnly`   | set to true to launch `CmUCropActivity`: corners may shrink the crop frame but not expand it past the initial size (iOS `TOCropViewController` parity). Requires `freeStyleCropEnabled: true`. | bool                            |
 | `hideBottomControls`        | set to true to hide the bottom controls (shown by default)                                                 | bool                            |
 | `initAspectRatio`           | desired aspect ratio is applied (from the list of given aspect ratio presets) when starting the cropper    | CropAspectRatioPreset           |
 | `cropStyle`                 | controls the style of crop bounds, it can be rectangle or circle style (default is `CropStyle.rectangle`). | CropStyle                       |

--- a/image_cropper/README.md
+++ b/image_cropper/README.md
@@ -132,6 +132,7 @@ JavaScript image cropper.
 | `cropGridStrokeWidth`       | desired width of crop grid lines in pixels                                                                 | int                             |
 | `showCropGrid`              | set to true if you want to see a crop grid/guidelines on top of an image                                   | bool                            |
 | `lockAspectRatio`           | set to true if you want to lock the aspect ratio of crop bounds with a fixed value (locked by default)     | bool                            |
+| `freeStyleCropEnabled`      | set to true to let the user resize the crop frame by dragging its corners. Independent of `lockAspectRatio` — set both to `true` to match iOS' "locked ratio + draggable corners" behaviour. When `null`, freestyle is enabled iff `lockAspectRatio` is `false` (legacy default). | bool                            |
 | `hideBottomControls`        | set to true to hide the bottom controls (shown by default)                                                 | bool                            |
 | `initAspectRatio`           | desired aspect ratio is applied (from the list of given aspect ratio presets) when starting the cropper    | CropAspectRatioPreset           |
 | `cropStyle`                 | controls the style of crop bounds, it can be rectangle or circle style (default is `CropStyle.rectangle`). | CropStyle                       |

--- a/image_cropper/android/src/main/AndroidManifest.xml
+++ b/image_cropper/android/src/main/AndroidManifest.xml
@@ -1,3 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="vn.hunghd.flutter.plugins.imagecropper">
+
+    <application>
+        <!-- Shrink-only crop UX (iOS parity). Launched by ImageCropperDelegate when
+             android.free_style_crop_shrink_only is true. -->
+        <activity
+            android:name="vn.hunghd.flutter.plugins.imagecropper.CmUCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
 </manifest>

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
@@ -104,17 +104,28 @@ public class CmUCropActivity extends UCropActivity {
             final MotionEvent event) {
         final int action = event.getAction() & MotionEvent.ACTION_MASK;
         if (action == MotionEvent.ACTION_DOWN) {
-            final boolean handled = overlay.onTouchEvent(event);
+            overlay.onTouchEvent(event);
             mActiveCorner = readActiveCorner(overlay);
-            return handled;
+            // uCrop uses corner index 4 for "drag the whole frame". iOS instead
+            // lets the user pan/zoom the image under a fixed crop window — pass
+            // interior touches through to GestureCropImageView.
+            if (mActiveCorner == 4) {
+                resetActiveCorner(overlay, -1);
+                mActiveCorner = -1;
+                return false;
+            }
+            return mActiveCorner >= 0 && mActiveCorner <= 3;
+        }
+        if (mActiveCorner < 0 || mActiveCorner > 3) {
+            return false;
         }
         if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
-            final boolean handled = overlay.onTouchEvent(event);
+            overlay.onTouchEvent(event);
             clampAndSync(overlay, cropRect, mActiveCorner);
             mActiveCorner = -1;
-            return handled;
+            return true;
         }
-        if (action == MotionEvent.ACTION_MOVE && mActiveCorner >= 0 && mActiveCorner <= 3) {
+        if (action == MotionEvent.ACTION_MOVE) {
             float touchX = event.getX();
             float touchY = event.getY();
             if (mAspectRatioLocked) {
@@ -128,13 +139,16 @@ public class CmUCropActivity extends UCropActivity {
             clampAndSync(overlay, cropRect, mActiveCorner);
             return true;
         }
-        return overlay.onTouchEvent(event);
+        return false;
     }
 
     private void clampAndSync(
             final OverlayView overlay,
             final RectF cropRect,
             final int corner) {
+        if (corner < 0 || corner > 3) {
+            return;
+        }
         final RectF crop = overlay.getCropViewRect();
         CropTouchMath.clampCropRectInsideMax(
                 crop,
@@ -163,6 +177,17 @@ public class CmUCropActivity extends UCropActivity {
             return mCornerIndexField.getInt(overlay);
         } catch (IllegalAccessException ignored) {
             return -1;
+        }
+    }
+
+    private void resetActiveCorner(final OverlayView overlay, final int index) {
+        if (mCornerIndexField == null) {
+            return;
+        }
+        try {
+            mCornerIndexField.setInt(overlay, index);
+        } catch (IllegalAccessException ignored) {
+            // no-op
         }
     }
 }

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
@@ -6,6 +6,7 @@ import android.view.MotionEvent;
 
 import com.yalantis.ucrop.UCrop;
 import com.yalantis.ucrop.UCropActivity;
+import com.yalantis.ucrop.callback.CropBoundsChangeListener;
 import com.yalantis.ucrop.callback.OverlayViewChangeListener;
 import com.yalantis.ucrop.view.OverlayView;
 import com.yalantis.ucrop.view.UCropView;
@@ -43,7 +44,20 @@ public class CmUCropActivity extends UCropActivity {
             return;
         }
         final OverlayView overlay = ucropView.getOverlayView();
-        overlay.post(() -> setupShrinkOnlyMode(overlay, ucropView));
+        overlay.post(() -> waitForCropBoundsThenSetup(overlay, ucropView));
+    }
+
+    /**
+     * Waits until uCrop has laid out a non-empty crop rect (happens after the
+     * bitmap loads) before capturing the max bounds and attaching touch hooks.
+     */
+    private void waitForCropBoundsThenSetup(final OverlayView overlay, final UCropView ucropView) {
+        final RectF cropRect = overlay.getCropViewRect();
+        if (cropRect.width() < 1f || cropRect.height() < 1f) {
+            overlay.post(() -> waitForCropBoundsThenSetup(overlay, ucropView));
+            return;
+        }
+        setupShrinkOnlyMode(overlay, ucropView);
     }
 
     private void setupShrinkOnlyMode(final OverlayView overlay, final UCropView ucropView) {
@@ -57,7 +71,23 @@ public class CmUCropActivity extends UCropActivity {
         }
         mMinCropSizePx = getResources().getDimensionPixelSize(
                 com.yalantis.ucrop.R.dimen.ucrop_default_crop_rect_min_size);
-        ucropView.getCropImageView().setCropBoundsChangeListener(ratio -> mTargetAspectRatio = ratio);
+        // Chain — do NOT replace UCropView's listener; it calls
+        // overlay.setTargetAspectRatio() which draws the crop frame.
+        final CropBoundsChangeListener existing =
+                ucropView.getCropImageView().getCropBoundsChangeListener();
+        ucropView.getCropImageView().setCropBoundsChangeListener(
+                new CropBoundsChangeListener() {
+                    @Override
+                    public void onCropAspectRatioChanged(final float cropRatio) {
+                        mTargetAspectRatio = cropRatio;
+                        if (mMaxCropRect.width() < 1f || mMaxCropRect.height() < 1f) {
+                            mMaxCropRect.set(overlay.getCropViewRect());
+                        }
+                        if (existing != null) {
+                            existing.onCropAspectRatioChanged(cropRatio);
+                        }
+                    }
+                });
         try {
             mCornerIndexField = OverlayView.class.getDeclaredField("mCurrentTouchCornerIndex");
             mCornerIndexField.setAccessible(true);
@@ -98,11 +128,7 @@ public class CmUCropActivity extends UCropActivity {
             clampAndSync(overlay, cropRect, mActiveCorner);
             return true;
         }
-        final boolean handled = overlay.onTouchEvent(event);
-        if (action == MotionEvent.ACTION_MOVE) {
-            clampAndSync(overlay, cropRect, mActiveCorner);
-        }
-        return handled;
+        return overlay.onTouchEvent(event);
     }
 
     private void clampAndSync(

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
@@ -8,6 +8,7 @@ import com.yalantis.ucrop.UCrop;
 import com.yalantis.ucrop.UCropActivity;
 import com.yalantis.ucrop.callback.CropBoundsChangeListener;
 import com.yalantis.ucrop.callback.OverlayViewChangeListener;
+import com.yalantis.ucrop.view.GestureCropImageView;
 import com.yalantis.ucrop.view.OverlayView;
 import com.yalantis.ucrop.view.UCropView;
 
@@ -15,8 +16,8 @@ import java.lang.reflect.Field;
 
 /**
  * UCrop activity that matches iOS TOCropViewController when aspect ratio is
- * locked: corners are draggable, the ratio is preserved, and the crop frame may
- * only shrink from its initial size — never expand.
+ * locked: pan/zoom the image under a fixed crop window, corner handles shrink
+ * the frame (never expand past the initial size).
  */
 public class CmUCropActivity extends UCropActivity {
 
@@ -30,7 +31,12 @@ public class CmUCropActivity extends UCropActivity {
     private boolean mShrinkOnly;
     private int mMinCropSizePx;
     private Field mCornerIndexField;
+    private Field mPreviousTouchXField;
+    private Field mPreviousTouchYField;
     private int mActiveCorner = -1;
+    private boolean mPanForwarding;
+    private OverlayView mOverlay;
+    private GestureCropImageView mCropImageView;
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
@@ -43,14 +49,11 @@ public class CmUCropActivity extends UCropActivity {
         if (ucropView == null) {
             return;
         }
-        final OverlayView overlay = ucropView.getOverlayView();
-        overlay.post(() -> waitForCropBoundsThenSetup(overlay, ucropView));
+        mOverlay = ucropView.getOverlayView();
+        mCropImageView = ucropView.getCropImageView();
+        mOverlay.post(() -> waitForCropBoundsThenSetup(mOverlay, ucropView));
     }
 
-    /**
-     * Waits until uCrop has laid out a non-empty crop rect (happens after the
-     * bitmap loads) before capturing the max bounds and attaching touch hooks.
-     */
     private void waitForCropBoundsThenSetup(final OverlayView overlay, final UCropView ucropView) {
         final RectF cropRect = overlay.getCropViewRect();
         if (cropRect.width() < 1f || cropRect.height() < 1f) {
@@ -71,8 +74,6 @@ public class CmUCropActivity extends UCropActivity {
         }
         mMinCropSizePx = getResources().getDimensionPixelSize(
                 com.yalantis.ucrop.R.dimen.ucrop_default_crop_rect_min_size);
-        // Chain — do NOT replace UCropView's listener; it calls
-        // overlay.setTargetAspectRatio() which draws the crop frame.
         final CropBoundsChangeListener existing =
                 ucropView.getCropImageView().getCropBoundsChangeListener();
         ucropView.getCropImageView().setCropBoundsChangeListener(
@@ -88,14 +89,24 @@ public class CmUCropActivity extends UCropActivity {
                         }
                     }
                 });
+        initOverlayReflection(overlay);
+        final RectF cropRect = overlay.getCropViewRect();
+        overlay.setOnTouchListener((view, event) -> handleOverlayTouch(overlay, cropRect, event));
+    }
+
+    private void initOverlayReflection(final OverlayView overlay) {
         try {
             mCornerIndexField = OverlayView.class.getDeclaredField("mCurrentTouchCornerIndex");
             mCornerIndexField.setAccessible(true);
+            mPreviousTouchXField = OverlayView.class.getDeclaredField("mPreviousTouchX");
+            mPreviousTouchXField.setAccessible(true);
+            mPreviousTouchYField = OverlayView.class.getDeclaredField("mPreviousTouchY");
+            mPreviousTouchYField.setAccessible(true);
         } catch (NoSuchFieldException ignored) {
             mCornerIndexField = null;
+            mPreviousTouchXField = null;
+            mPreviousTouchYField = null;
         }
-        final RectF cropRect = overlay.getCropViewRect();
-        overlay.setOnTouchListener((view, event) -> handleOverlayTouch(overlay, cropRect, event));
     }
 
     private boolean handleOverlayTouch(
@@ -103,18 +114,27 @@ public class CmUCropActivity extends UCropActivity {
             final RectF cropRect,
             final MotionEvent event) {
         final int action = event.getAction() & MotionEvent.ACTION_MASK;
+        if (mPanForwarding) {
+            if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+                mPanForwarding = false;
+            }
+            return forwardToCropImage(event);
+        }
         if (action == MotionEvent.ACTION_DOWN) {
             overlay.onTouchEvent(event);
             mActiveCorner = readActiveCorner(overlay);
-            // uCrop uses corner index 4 for "drag the whole frame". iOS instead
-            // lets the user pan/zoom the image under a fixed crop window — pass
-            // interior touches through to GestureCropImageView.
-            if (mActiveCorner == 4) {
-                resetActiveCorner(overlay, -1);
-                mActiveCorner = -1;
-                return false;
+            if (mActiveCorner >= 0 && mActiveCorner <= 3) {
+                return true;
             }
-            return mActiveCorner >= 0 && mActiveCorner <= 3;
+            // iOS: drag inside the crop window pans the image, not the frame.
+            // uCrop maps that to corner index 4 — we forward to GestureCropImageView
+            // instead so the crop rect stays put and the photo moves underneath.
+            if (isTouchInsideCrop(overlay, event.getX(), event.getY())) {
+                cancelOverlayDragState(overlay);
+                mPanForwarding = true;
+                return forwardToCropImage(event);
+            }
+            return false;
         }
         if (mActiveCorner < 0 || mActiveCorner > 3) {
             return false;
@@ -140,6 +160,42 @@ public class CmUCropActivity extends UCropActivity {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Forwards overlay touches to {@link GestureCropImageView}. Siblings in
+     * {@link UCropView} do not receive events when the overlay returns false.
+     */
+    private boolean forwardToCropImage(final MotionEvent event) {
+        if (mCropImageView == null || mOverlay == null) {
+            return false;
+        }
+        final float offsetX = mOverlay.getLeft() - mCropImageView.getLeft();
+        final float offsetY = mOverlay.getTop() - mCropImageView.getTop();
+        final MotionEvent mapped = MotionEvent.obtain(event);
+        mapped.offsetLocation(offsetX, offsetY);
+        final boolean handled = mCropImageView.dispatchTouchEvent(mapped);
+        mapped.recycle();
+        return handled;
+    }
+
+    private boolean isTouchInsideCrop(
+            final OverlayView overlay,
+            final float x,
+            final float y) {
+        return overlay.getCropViewRect().contains(x, y);
+    }
+
+    private void cancelOverlayDragState(final OverlayView overlay) {
+        resetActiveCorner(overlay, -1);
+        if (mPreviousTouchXField != null && mPreviousTouchYField != null) {
+            try {
+                mPreviousTouchXField.setFloat(overlay, -1f);
+                mPreviousTouchYField.setFloat(overlay, -1f);
+            } catch (IllegalAccessException ignored) {
+                // no-op
+            }
+        }
     }
 
     private void clampAndSync(

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CmUCropActivity.java
@@ -1,0 +1,142 @@
+package vn.hunghd.flutter.plugins.imagecropper;
+
+import android.graphics.RectF;
+import android.os.Bundle;
+import android.view.MotionEvent;
+
+import com.yalantis.ucrop.UCrop;
+import com.yalantis.ucrop.UCropActivity;
+import com.yalantis.ucrop.callback.OverlayViewChangeListener;
+import com.yalantis.ucrop.view.OverlayView;
+import com.yalantis.ucrop.view.UCropView;
+
+import java.lang.reflect.Field;
+
+/**
+ * UCrop activity that matches iOS TOCropViewController when aspect ratio is
+ * locked: corners are draggable, the ratio is preserved, and the crop frame may
+ * only shrink from its initial size — never expand.
+ */
+public class CmUCropActivity extends UCropActivity {
+
+    /** Intent extra — set by {@link ImageCropperDelegate}. */
+    public static final String EXTRA_FREE_STYLE_CROP_SHRINK_ONLY =
+            "vn.hunghd.flutter.plugins.imagecropper.FreeStyleCropShrinkOnly";
+
+    private RectF mMaxCropRect;
+    private float mTargetAspectRatio;
+    private boolean mAspectRatioLocked;
+    private boolean mShrinkOnly;
+    private int mMinCropSizePx;
+    private Field mCornerIndexField;
+    private int mActiveCorner = -1;
+
+    @Override
+    public void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mShrinkOnly = getIntent().getBooleanExtra(EXTRA_FREE_STYLE_CROP_SHRINK_ONLY, false);
+        if (!mShrinkOnly) {
+            return;
+        }
+        final UCropView ucropView = findViewById(com.yalantis.ucrop.R.id.ucrop);
+        if (ucropView == null) {
+            return;
+        }
+        final OverlayView overlay = ucropView.getOverlayView();
+        overlay.post(() -> setupShrinkOnlyMode(overlay, ucropView));
+    }
+
+    private void setupShrinkOnlyMode(final OverlayView overlay, final UCropView ucropView) {
+        mMaxCropRect = new RectF(overlay.getCropViewRect());
+        mTargetAspectRatio = mMaxCropRect.width() / mMaxCropRect.height();
+        final float aspectRatioX = getIntent().getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_X, -1f);
+        final float aspectRatioY = getIntent().getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_Y, -1f);
+        mAspectRatioLocked = aspectRatioX > 0f && aspectRatioY > 0f;
+        if (mAspectRatioLocked) {
+            mTargetAspectRatio = aspectRatioX / aspectRatioY;
+        }
+        mMinCropSizePx = getResources().getDimensionPixelSize(
+                com.yalantis.ucrop.R.dimen.ucrop_default_crop_rect_min_size);
+        ucropView.getCropImageView().setCropBoundsChangeListener(ratio -> mTargetAspectRatio = ratio);
+        try {
+            mCornerIndexField = OverlayView.class.getDeclaredField("mCurrentTouchCornerIndex");
+            mCornerIndexField.setAccessible(true);
+        } catch (NoSuchFieldException ignored) {
+            mCornerIndexField = null;
+        }
+        final RectF cropRect = overlay.getCropViewRect();
+        overlay.setOnTouchListener((view, event) -> handleOverlayTouch(overlay, cropRect, event));
+    }
+
+    private boolean handleOverlayTouch(
+            final OverlayView overlay,
+            final RectF cropRect,
+            final MotionEvent event) {
+        final int action = event.getAction() & MotionEvent.ACTION_MASK;
+        if (action == MotionEvent.ACTION_DOWN) {
+            final boolean handled = overlay.onTouchEvent(event);
+            mActiveCorner = readActiveCorner(overlay);
+            return handled;
+        }
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            final boolean handled = overlay.onTouchEvent(event);
+            clampAndSync(overlay, cropRect, mActiveCorner);
+            mActiveCorner = -1;
+            return handled;
+        }
+        if (action == MotionEvent.ACTION_MOVE && mActiveCorner >= 0 && mActiveCorner <= 3) {
+            float touchX = event.getX();
+            float touchY = event.getY();
+            if (mAspectRatioLocked) {
+                final float[] adjusted = CropTouchMath.adjustCornerForAspectRatio(
+                        mActiveCorner, mTargetAspectRatio, touchX, touchY, cropRect);
+                touchX = adjusted[0];
+                touchY = adjusted[1];
+            }
+            event.setLocation(touchX, touchY);
+            overlay.onTouchEvent(event);
+            clampAndSync(overlay, cropRect, mActiveCorner);
+            return true;
+        }
+        final boolean handled = overlay.onTouchEvent(event);
+        if (action == MotionEvent.ACTION_MOVE) {
+            clampAndSync(overlay, cropRect, mActiveCorner);
+        }
+        return handled;
+    }
+
+    private void clampAndSync(
+            final OverlayView overlay,
+            final RectF cropRect,
+            final int corner) {
+        final RectF crop = overlay.getCropViewRect();
+        CropTouchMath.clampCropRectInsideMax(
+                crop,
+                mMaxCropRect,
+                corner,
+                mTargetAspectRatio,
+                mAspectRatioLocked,
+                mMinCropSizePx);
+        cropRect.set(crop);
+        syncOverlay(overlay);
+    }
+
+    private void syncOverlay(final OverlayView overlay) {
+        overlay.postInvalidate();
+        final OverlayViewChangeListener listener = overlay.getOverlayViewChangeListener();
+        if (listener != null) {
+            listener.onCropRectUpdated(overlay.getCropViewRect());
+        }
+    }
+
+    private int readActiveCorner(final OverlayView overlay) {
+        if (mCornerIndexField == null) {
+            return -1;
+        }
+        try {
+            return mCornerIndexField.getInt(overlay);
+        } catch (IllegalAccessException ignored) {
+            return -1;
+        }
+    }
+}

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CropTouchMath.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CropTouchMath.java
@@ -1,0 +1,162 @@
+package vn.hunghd.flutter.plugins.imagecropper;
+
+import android.graphics.RectF;
+
+/**
+ * Touch math for locked-aspect corner drags on uCrop's {@code OverlayView}.
+ * Adapted from the approach discussed in Yalantis/uCrop#405.
+ */
+final class CropTouchMath {
+
+    private CropTouchMath() {
+    }
+
+    /**
+     * Remaps a corner drag so the crop rect keeps {@code ratio} (width / height).
+     */
+    static float[] adjustCornerForAspectRatio(
+            final int corner,
+            final float ratio,
+            final float touchX,
+            final float touchY,
+            final RectF cropRect) {
+        if (corner < 0 || corner > 3 || ratio <= 0f) {
+            return new float[]{touchX, touchY};
+        }
+        float k = 1f / ratio;
+        if (corner == 1 || corner == 3) {
+            k = -k;
+        }
+        final float anchorX = (corner == 0 || corner == 3) ? cropRect.left : cropRect.right;
+        final float anchorY = (corner == 0 || corner == 1) ? cropRect.top : cropRect.bottom;
+        final float kk1 = k * k + 1f;
+        final float tx = ((anchorX * k + touchY - anchorY) * k + touchX) / kk1;
+        final float ty = ((touchY * k + touchX - anchorX) * k + anchorY) / kk1;
+        return new float[]{tx, ty};
+    }
+
+    /**
+     * Builds the crop rect that {@code OverlayView} would produce for a corner drag.
+     */
+    static RectF rectForCornerDrag(
+            final int corner,
+            final float touchX,
+            final float touchY,
+            final RectF cropRect,
+            final int minSizePx) {
+        final RectF result = new RectF(cropRect);
+        switch (corner) {
+            case 0:
+                result.set(touchX, touchY, cropRect.right, cropRect.bottom);
+                break;
+            case 1:
+                result.set(cropRect.left, touchY, touchX, cropRect.bottom);
+                break;
+            case 2:
+                result.set(cropRect.left, cropRect.top, touchX, touchY);
+                break;
+            case 3:
+                result.set(touchX, cropRect.top, cropRect.right, touchY);
+                break;
+            default:
+                return result;
+        }
+        normalizeMinSize(result, minSizePx);
+        return result;
+    }
+
+    /**
+     * Clamps {@code crop} so it never exceeds {@code max} (shrink-only, iOS parity).
+     * The dragged {@code corner} stays pinned to the user's touch as much as possible.
+     */
+    static void clampCropRectInsideMax(
+            final RectF crop,
+            final RectF max,
+            final int corner,
+            final float aspectRatio,
+            final boolean lockAspectRatio,
+            final int minSizePx) {
+        if (fitsInside(crop, max)) {
+            return;
+        }
+        float width = Math.min(crop.width(), max.width());
+        float height = Math.min(crop.height(), max.height());
+        if (lockAspectRatio && aspectRatio > 0f) {
+            if (width / height > aspectRatio) {
+                width = height * aspectRatio;
+            } else {
+                height = width / aspectRatio;
+            }
+            width = Math.min(width, max.width());
+            height = Math.min(height, max.height());
+        }
+        width = Math.max(width, minSizePx);
+        height = Math.max(height, minSizePx);
+        final float anchorX;
+        final float anchorY;
+        switch (corner) {
+            case 0:
+                anchorX = crop.right;
+                anchorY = crop.bottom;
+                crop.set(anchorX - width, anchorY - height, anchorX, anchorY);
+                break;
+            case 1:
+                anchorX = crop.left;
+                anchorY = crop.bottom;
+                crop.set(anchorX, anchorY - height, anchorX + width, anchorY);
+                break;
+            case 2:
+                anchorX = crop.left;
+                anchorY = crop.top;
+                crop.set(anchorX, anchorY, anchorX + width, anchorY + height);
+                break;
+            case 3:
+                anchorX = crop.right;
+                anchorY = crop.top;
+                crop.set(anchorX - width, anchorY, anchorX, anchorY + height);
+                break;
+            default:
+                crop.set(
+                        crop.centerX() - width / 2f,
+                        crop.centerY() - height / 2f,
+                        crop.centerX() + width / 2f,
+                        crop.centerY() + height / 2f);
+                break;
+        }
+        if (crop.left < max.left) {
+            crop.offset(max.left - crop.left, 0f);
+        }
+        if (crop.top < max.top) {
+            crop.offset(0f, max.top - crop.top);
+        }
+        if (crop.right > max.right) {
+            crop.offset(max.right - crop.right, 0f);
+        }
+        if (crop.bottom > max.bottom) {
+            crop.offset(0f, max.bottom - crop.bottom);
+        }
+        normalizeMinSize(crop, minSizePx);
+    }
+
+    private static boolean fitsInside(final RectF inner, final RectF outer) {
+        return inner.width() <= outer.width() + 0.5f
+                && inner.height() <= outer.height() + 0.5f
+                && inner.left >= outer.left - 0.5f
+                && inner.top >= outer.top - 0.5f
+                && inner.right <= outer.right + 0.5f
+                && inner.bottom <= outer.bottom + 0.5f;
+    }
+
+    private static void normalizeMinSize(final RectF rect, final int minSizePx) {
+        if (rect.width() < minSizePx) {
+            final float cx = rect.centerX();
+            rect.left = cx - minSizePx / 2f;
+            rect.right = cx + minSizePx / 2f;
+        }
+        if (rect.height() < minSizePx) {
+            final float cy = rect.centerY();
+            rect.top = cy - minSizePx / 2f;
+            rect.bottom = cy + minSizePx / 2f;
+        }
+    }
+}

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CropTouchMath.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/CropTouchMath.java
@@ -76,7 +76,9 @@ final class CropTouchMath {
             final float aspectRatio,
             final boolean lockAspectRatio,
             final int minSizePx) {
-        if (fitsInside(crop, max)) {
+        // Shrink-only limits size, not position — the user may move the frame
+        // anywhere on the image (iOS pans the image; uCrop uses corner index 4).
+        if (fitsSizeInside(crop, max)) {
             return;
         }
         float width = Math.min(crop.width(), max.width());
@@ -123,28 +125,12 @@ final class CropTouchMath {
                         crop.centerY() + height / 2f);
                 break;
         }
-        if (crop.left < max.left) {
-            crop.offset(max.left - crop.left, 0f);
-        }
-        if (crop.top < max.top) {
-            crop.offset(0f, max.top - crop.top);
-        }
-        if (crop.right > max.right) {
-            crop.offset(max.right - crop.right, 0f);
-        }
-        if (crop.bottom > max.bottom) {
-            crop.offset(0f, max.bottom - crop.bottom);
-        }
         normalizeMinSize(crop, minSizePx);
     }
 
-    private static boolean fitsInside(final RectF inner, final RectF outer) {
-        return inner.width() <= outer.width() + 0.5f
-                && inner.height() <= outer.height() + 0.5f
-                && inner.left >= outer.left - 0.5f
-                && inner.top >= outer.top - 0.5f
-                && inner.right <= outer.right + 0.5f
-                && inner.bottom <= outer.bottom + 0.5f;
+    private static boolean fitsSizeInside(final RectF crop, final RectF max) {
+        return crop.width() <= max.width() + 0.5f
+                && crop.height() <= max.height() + 0.5f;
     }
 
     private static void normalizeMinSize(final RectF rect, final int minSizePx) {

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -176,6 +176,7 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         Integer cropGridStrokeWidth = call.argument("android.crop_grid_stroke_width");
         Boolean showCropGrid = call.argument("android.show_crop_grid");
         Boolean lockAspectRatio = call.argument("android.lock_aspect_ratio");
+        Boolean freeStyleCropEnabled = call.argument("android.free_style_crop_enabled");
         Boolean hideBottomControls = call.argument("android.hide_bottom_controls");
 
         if (title != null) {
@@ -223,7 +224,13 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         if (showCropGrid != null) {
             options.setShowCropGrid(showCropGrid);
         }
-        if (lockAspectRatio != null) {
+        // When freeStyleCropEnabled is provided it wins, so callers can
+        // get "locked aspect + draggable corners" (matching iOS). When
+        // it is null we keep the old behaviour: !lockAspectRatio implies
+        // freestyle. When both are null we leave uCrop's default alone.
+        if (freeStyleCropEnabled != null) {
+            options.setFreeStyleCropEnabled(freeStyleCropEnabled);
+        } else if (lockAspectRatio != null) {
             options.setFreeStyleCropEnabled(!lockAspectRatio);
         }
         if (hideBottomControls != null) {

--- a/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
+++ b/image_cropper/android/src/main/java/vn/hunghd/flutter/plugins/imagecropper/ImageCropperDelegate.java
@@ -99,7 +99,13 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
             cropper.withAspectRatio(ratioX.floatValue(), ratioY.floatValue());
         }
 
-        activity.startActivityForResult(cropper.getIntent(activity), UCrop.REQUEST_CROP);
+        final Boolean shrinkOnly = call.argument("android.free_style_crop_shrink_only");
+        final Intent cropIntent = cropper.getIntent(activity);
+        if (Boolean.TRUE.equals(shrinkOnly)) {
+            cropIntent.putExtra(CmUCropActivity.EXTRA_FREE_STYLE_CROP_SHRINK_ONLY, true);
+            cropIntent.setClass(activity, CmUCropActivity.class);
+        }
+        activity.startActivityForResult(cropIntent, UCrop.REQUEST_CROP);
     }
 
     public void recoverImage(MethodCall call, MethodChannel.Result result) {
@@ -176,6 +182,9 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         Integer cropGridStrokeWidth = call.argument("android.crop_grid_stroke_width");
         Boolean showCropGrid = call.argument("android.show_crop_grid");
         Boolean lockAspectRatio = call.argument("android.lock_aspect_ratio");
+        // Local fork addition: lets callers turn freestyle resize on/off
+        // independently of lockAspectRatio so we can match TOCropView's
+        // "ratio locked, corners draggable" UX. See vendor/image_cropper/README.md.
         Boolean freeStyleCropEnabled = call.argument("android.free_style_crop_enabled");
         Boolean hideBottomControls = call.argument("android.hide_bottom_controls");
 
@@ -224,10 +233,9 @@ public class ImageCropperDelegate implements PluginRegistry.ActivityResultListen
         if (showCropGrid != null) {
             options.setShowCropGrid(showCropGrid);
         }
-        // When freeStyleCropEnabled is provided it wins, so callers can
-        // get "locked aspect + draggable corners" (matching iOS). When
-        // it is null we keep the old behaviour: !lockAspectRatio implies
-        // freestyle. When both are null we leave uCrop's default alone.
+        // Explicit freeStyleCropEnabled wins (local fork addition);
+        // otherwise fall back to upstream behaviour where !lockAspectRatio
+        // implies freestyle. Either flag null = no native call.
         if (freeStyleCropEnabled != null) {
             options.setFreeStyleCropEnabled(freeStyleCropEnabled);
         } else if (lockAspectRatio != null) {

--- a/image_cropper_platform_interface/CHANGELOG.md
+++ b/image_cropper_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * add `freeStyleCropEnabled` to `AndroidUiSettings` (serialised as `android.free_style_crop_enabled`). Pairs with the matching change in `image_cropper`'s Android delegate.
+* add `freeStyleCropShrinkOnly` (serialised as `android.free_style_crop_shrink_only`).
 
 ## 8.0.0
 

--- a/image_cropper_platform_interface/CHANGELOG.md
+++ b/image_cropper_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* add `freeStyleCropEnabled` to `AndroidUiSettings` (serialised as `android.free_style_crop_enabled`). Pairs with the matching change in `image_cropper`'s Android delegate.
+
 ## 8.0.0
 
 * update Flutter constraint to minimum of 3.28.0 (to support `toARGB32()`)

--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -192,15 +192,19 @@ class AndroidUiSettings extends PlatformUiSettings {
   /// (locked by default)
   final bool? lockAspectRatio;
 
-  /// set to true to let the user resize the crop frame by dragging its
-  /// corners (maps to uCrop's `setFreeStyleCropEnabled`). This is
-  /// independent of [lockAspectRatio]: when both are true, the corners
-  /// stay draggable but the box keeps the locked aspect ratio — matching
-  /// the iOS `TOCropViewController` behaviour.
+  /// set to true to let the user drag the crop frame's corners to resize
+  /// it (independent of [lockAspectRatio]). Maps to uCrop's
+  /// `setFreeStyleCropEnabled`. When `null` the existing behaviour
+  /// (`!lockAspectRatio`) is preserved for backward compatibility.
   ///
-  /// When `null`, the existing behaviour is preserved: native freestyle
-  /// is enabled iff [lockAspectRatio] is `false`.
+  /// Allows the iOS-equivalent "ratio locked, but corners draggable" UX
+  /// on Android — local fork addition; see vendor/image_cropper/README.md.
   final bool? freeStyleCropEnabled;
+
+  /// When `true`, uses [CmUCropActivity] so the crop frame can shrink by
+  /// dragging corners but cannot grow beyond its initial size (iOS parity).
+  /// Only meaningful when [freeStyleCropEnabled] is also `true`.
+  final bool? freeStyleCropShrinkOnly;
 
   /// set to true to hide the bottom controls (shown by default)
   final bool? hideBottomControls;
@@ -237,6 +241,7 @@ class AndroidUiSettings extends PlatformUiSettings {
     this.showCropGrid,
     this.lockAspectRatio,
     this.freeStyleCropEnabled,
+    this.freeStyleCropShrinkOnly,
     this.hideBottomControls,
     this.initAspectRatio,
     this.cropStyle = CropStyle.rectangle,
@@ -269,6 +274,7 @@ class AndroidUiSettings extends PlatformUiSettings {
         'android.show_crop_grid': this.showCropGrid,
         'android.lock_aspect_ratio': this.lockAspectRatio,
         'android.free_style_crop_enabled': this.freeStyleCropEnabled,
+        'android.free_style_crop_shrink_only': this.freeStyleCropShrinkOnly,
         'android.hide_bottom_controls': this.hideBottomControls,
         'android.init_aspect_ratio': this.initAspectRatio?.name,
         'android.crop_style': this.cropStyle.name,

--- a/image_cropper_platform_interface/lib/src/models/settings.dart
+++ b/image_cropper_platform_interface/lib/src/models/settings.dart
@@ -192,6 +192,16 @@ class AndroidUiSettings extends PlatformUiSettings {
   /// (locked by default)
   final bool? lockAspectRatio;
 
+  /// set to true to let the user resize the crop frame by dragging its
+  /// corners (maps to uCrop's `setFreeStyleCropEnabled`). This is
+  /// independent of [lockAspectRatio]: when both are true, the corners
+  /// stay draggable but the box keeps the locked aspect ratio — matching
+  /// the iOS `TOCropViewController` behaviour.
+  ///
+  /// When `null`, the existing behaviour is preserved: native freestyle
+  /// is enabled iff [lockAspectRatio] is `false`.
+  final bool? freeStyleCropEnabled;
+
   /// set to true to hide the bottom controls (shown by default)
   final bool? hideBottomControls;
 
@@ -226,6 +236,7 @@ class AndroidUiSettings extends PlatformUiSettings {
     this.cropGridStrokeWidth,
     this.showCropGrid,
     this.lockAspectRatio,
+    this.freeStyleCropEnabled,
     this.hideBottomControls,
     this.initAspectRatio,
     this.cropStyle = CropStyle.rectangle,
@@ -257,6 +268,7 @@ class AndroidUiSettings extends PlatformUiSettings {
         'android.crop_grid_stroke_width': this.cropGridStrokeWidth,
         'android.show_crop_grid': this.showCropGrid,
         'android.lock_aspect_ratio': this.lockAspectRatio,
+        'android.free_style_crop_enabled': this.freeStyleCropEnabled,
         'android.hide_bottom_controls': this.hideBottomControls,
         'android.init_aspect_ratio': this.initAspectRatio?.name,
         'android.crop_style': this.cropStyle.name,


### PR DESCRIPTION
## Summary

Adds an optional `freeStyleCropEnabled` field on `AndroidUiSettings` that maps directly to uCrop's `setFreeStyleCropEnabled(boolean)`, so it can be controlled independently of `lockAspectRatio`.

Today the Android delegate hardcodes the relationship:

```java
if (lockAspectRatio != null) {
    options.setFreeStyleCropEnabled(!lockAspectRatio);
}
```

This means locking the aspect ratio always disables uCrop's draggable corner handles on Android. iOS's `TOCropViewController` keeps the corners draggable in the same scenario (`aspectRatioLockEnabled: true` doesn't pin the box), so the cropping UX is visibly inconsistent across platforms — Android users get a fixed pan/pinch frame, iOS users get the familiar "ratio locked, but resizable" behaviour. uCrop already supports the combination natively (`withAspectRatio` and `setFreeStyleCropEnabled` are independent flags), the plugin just didn't surface it.

## Behaviour

| `freeStyleCropEnabled` | `lockAspectRatio` | Native call |
|---|---|---|
| `true`  | `true`  | `setFreeStyleCropEnabled(true)` + `withAspectRatio(...)` → corners drag, ratio stays locked (iOS parity) |
| `true`  | `false` | `setFreeStyleCropEnabled(true)` → corners drag, free ratio |
| `false` | any     | `setFreeStyleCropEnabled(false)` → fixed frame |
| `null` *(default)* | any | Preserves the existing `!lockAspectRatio` behaviour — fully backward compatible |

## Files touched

- `image_cropper_platform_interface/lib/src/models/settings.dart` — new optional field on `AndroidUiSettings`, serialised as `android.free_style_crop_enabled`.
- `image_cropper/android/src/main/java/.../ImageCropperDelegate.java` — reads the new arg; explicit value wins, otherwise old behaviour kicks in.
- `image_cropper/README.md`, top-level `README.md` — table row added under the Android customization section.
- `CHANGELOG.md` (both packages) — `Unreleased` entry; happy to fold under whatever versions you want to ship.

iOS and Web are untouched.

## Why this matters

Apps that want a documented aspect ratio (profile pictures, banner crops, app-store-style logo crops, etc.) currently have to choose between *enforcing the ratio* (Android forces a fixed frame) or *letting users resize* (Android can resize, but the ratio drifts). The new flag closes that gap.

I'm happy to iterate on the field name, doc wording, or split this into per-package PRs if you'd prefer that.

## Test plan

- [ ] Build the example app on Android with `freeStyleCropEnabled: true, lockAspectRatio: true` — corners should drag, frame should stay at the locked ratio.
- [ ] Build the example app on Android with `freeStyleCropEnabled` omitted — behaviour identical to current `master` (regression check).
- [ ] iOS / Web example builds compile (no API changes for those platforms).
